### PR TITLE
DMF01-25-cadastro-de-autor

### DIFF
--- a/src/main/java/com/dmf/loja/novoautor/Autor.java
+++ b/src/main/java/com/dmf/loja/novoautor/Autor.java
@@ -1,0 +1,64 @@
+package com.dmf.loja.novoautor;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.util.Assert;
+
+import java.time.Instant;
+
+@Entity
+public class Autor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String nome;
+
+    @NotBlank
+    @Email
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @NotBlank
+    @Size(max = 400)
+    @Column(nullable = false, length = 400)
+    private String descricao;
+
+    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    private Instant instanteCriacao;
+
+    public Autor(
+            final String nome,
+            final String email,
+            final String descricao
+    ) {
+        Assert.hasText(nome, "O nome é obrigatório");
+        Assert.hasText(email, "O email é obrigatório");
+        Assert.hasText(descricao, "A descrição é obrigatória");
+        Assert.isTrue(descricao.length() <= 400, "A descrição não pode passar de 400 caracteres");
+
+        this.nome = nome;
+        this.email = email;
+        this.descricao = descricao;
+        this.instanteCriacao = Instant.now();
+    }
+
+    @Deprecated
+    public Autor() {}
+
+    @Override
+    public String toString() {
+        return "Autor{" +
+                "id=" + id +
+                ", nome='" + nome + '\'' +
+                ", email='" + email + '\'' +
+                ", descricao='" + descricao + '\'' +
+                ", instanteCriacao=" + instanteCriacao +
+                '}';
+    }
+}

--- a/src/main/java/com/dmf/loja/novoautor/AutorRepository.java
+++ b/src/main/java/com/dmf/loja/novoautor/AutorRepository.java
@@ -1,0 +1,9 @@
+package com.dmf.loja.novoautor;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface AutorRepository extends CrudRepository<Autor, Long> {
+
+    boolean existsByEmail(String email);
+
+}

--- a/src/main/java/com/dmf/loja/novoautor/AutoresController.java
+++ b/src/main/java/com/dmf/loja/novoautor/AutoresController.java
@@ -13,8 +13,17 @@ public class AutoresController {
 
     private final EntityManager entityManager;
 
-    public AutoresController(EntityManager entityManager) {
+    //1
+    private final ProibeEmailDuplicadoAutorValidator proibeEmailDuplicadoAutorValidator;
+
+    public AutoresController(EntityManager entityManager, ProibeEmailDuplicadoAutorValidator proibeEmailDuplicadoAutorValidator) {
         this.entityManager = entityManager;
+        this.proibeEmailDuplicadoAutorValidator = proibeEmailDuplicadoAutorValidator;
+    }
+
+    @InitBinder
+    public void init(WebDataBinder binder) {
+        binder.addValidators(proibeEmailDuplicadoAutorValidator);
     }
 
     @PostMapping(value = "/autores")

--- a/src/main/java/com/dmf/loja/novoautor/AutoresController.java
+++ b/src/main/java/com/dmf/loja/novoautor/AutoresController.java
@@ -1,0 +1,30 @@
+package com.dmf.loja.novoautor;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.*;
+
+//3
+@RestController
+public class AutoresController {
+
+    private final EntityManager entityManager;
+
+    public AutoresController(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @PostMapping(value = "/autores")
+    @Transactional
+    @ResponseStatus(HttpStatus.OK)
+    //1
+    public String criaAutor(@RequestBody @Valid NovoAutorRequest novoAutorRequest) {
+        //1
+        Autor novoAutor = novoAutorRequest.toModel();
+        entityManager.persist(novoAutor);
+        return novoAutor.toString();
+    }
+}

--- a/src/main/java/com/dmf/loja/novoautor/NovoAutorRequest.java
+++ b/src/main/java/com/dmf/loja/novoautor/NovoAutorRequest.java
@@ -1,0 +1,22 @@
+package com.dmf.loja.novoautor;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NovoAutorRequest(
+        @NotBlank
+        String nome,
+
+        @NotBlank
+        @Email
+        String email,
+
+        @NotBlank
+        @Size(max = 400)
+        String descricao
+) {
+    public Autor toModel() {
+        return new Autor(this.nome, this.email, this.descricao);
+    }
+}

--- a/src/main/java/com/dmf/loja/novoautor/ProibeEmailDuplicadoAutorValidator.java
+++ b/src/main/java/com/dmf/loja/novoautor/ProibeEmailDuplicadoAutorValidator.java
@@ -1,0 +1,33 @@
+package com.dmf.loja.novoautor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+@Component
+public class ProibeEmailDuplicadoAutorValidator implements Validator {
+
+    private final AutorRepository autorRepository;
+
+    public ProibeEmailDuplicadoAutorValidator(AutorRepository autorRepository) {
+        this.autorRepository = autorRepository;
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return NovoAutorRequest.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        if (errors.hasErrors()) {
+            return;
+        }
+
+        NovoAutorRequest request = (NovoAutorRequest) target;
+
+        if (autorRepository.existsByEmail(request.email())) {
+            errors.rejectValue("email", null, "Já existe um autor cadastrado com este e-mail: " + request.email());
+        }
+    }
+}

--- a/src/main/java/com/dmf/loja/validation/ApplicationControllerAdvice.java
+++ b/src/main/java/com/dmf/loja/validation/ApplicationControllerAdvice.java
@@ -1,0 +1,44 @@
+package com.dmf.loja.validation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+//3
+@RestControllerAdvice
+public class ApplicationControllerAdvice {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApplicationControllerAdvice.class);
+
+    //1
+    private final MessageService messageService;
+
+    public ApplicationControllerAdvice(MessageService messageService) {
+        this.messageService = messageService;
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    //1
+    public ValidationErrorsResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        logger.warn("Erro de validação: {}", exception.getBindingResult());
+
+        return new ValidationErrorsResponse(
+                exception.getBindingResult().getGlobalErrors(),
+                exception.getBindingResult().getFieldErrors(),
+                messageService
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(Exception.class)
+    public ValidationErrorsResponse handleGenericException(Exception exception) {
+        logger.error("Unexpected error occurred: {}", exception.getMessage(), exception);
+        return new ValidationErrorsResponse("An unexpected error occurred. Please contact support.");
+    }
+
+}

--- a/src/main/java/com/dmf/loja/validation/FieldErrorsResponse.java
+++ b/src/main/java/com/dmf/loja/validation/FieldErrorsResponse.java
@@ -1,0 +1,7 @@
+package com.dmf.loja.validation;
+
+public record FieldErrorsResponse(
+        String field,
+        String message)
+{
+}

--- a/src/main/java/com/dmf/loja/validation/MessageService.java
+++ b/src/main/java/com/dmf/loja/validation/MessageService.java
@@ -1,0 +1,19 @@
+package com.dmf.loja.validation;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.ObjectError;
+
+@Service
+public class MessageService {
+    private final MessageSource messageSource;
+
+    public MessageService(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
+
+    public String getMessage(ObjectError error) {
+        return messageSource.getMessage(error, LocaleContextHolder.getLocale());
+    }
+}

--- a/src/main/java/com/dmf/loja/validation/ValidationErrorsResponse.java
+++ b/src/main/java/com/dmf/loja/validation/ValidationErrorsResponse.java
@@ -1,0 +1,51 @@
+package com.dmf.loja.validation;
+
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ValidationErrorsResponse {
+    private final String message;
+
+    //1
+    private final List<FieldErrorsResponse> errors;
+
+    public ValidationErrorsResponse(String message) {
+        this.message = message;
+        this.errors = List.of();
+    }
+
+    //1
+    public ValidationErrorsResponse(List<ObjectError> globalErrors, List<FieldError> fieldErrors, MessageService messageService) {
+        this.message = "Erro de validação";
+        List<FieldErrorsResponse> combinedErrors = new ArrayList<>();
+
+        combinedErrors.addAll(mapGlobalErrors(globalErrors));
+        combinedErrors.addAll(mapFieldErrors(fieldErrors, messageService));
+        this.errors = Collections.unmodifiableList(combinedErrors);
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public List<FieldErrorsResponse> getErrors() {
+        return errors;
+    }
+
+    private List<FieldErrorsResponse> mapFieldErrors(List<FieldError> fieldErrors, MessageService messageService) {
+        return fieldErrors.stream()
+                .map(error -> new FieldErrorsResponse(error.getField(), messageService.getMessage(error)))
+                .collect(Collectors.toList());
+    }
+
+    private List<FieldErrorsResponse> mapGlobalErrors(List<ObjectError> globalErrors) {
+        return globalErrors.stream()
+                .map(error -> new FieldErrorsResponse(null, error.getDefaultMessage()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,4 @@
+NotBlank.nome = nome é obrigatório
+NotBlank.email = email é obrigatório
+NotBlank.descricao = descrição é obrigatório
+NotBlank = campo obrigatório


### PR DESCRIPTION
Cadastro de autor

Necessidades
- É necessário cadastrar um novo autor no sistema.
- Todo autor tem um nome, email e uma descrição.
- Também queremos saber o instante exato que ele foi registrado.

Restrições
- O instante não pode ser nulo
- O email é obrigatório
- O email tem que ter formato válido
- O email do autor precisa ser único no sistema
- O nome é obrigatório
- A descrição é obrigatória e não pode passar de 400 caracteres
- Criar um @restcontrolleradvice para customizar o json de saída com erros de validação
- Externalizar as mensagens de erro no arquivo de configuração.

 Resultado esperado
- Um novo autor criado e status 200 retornado
- Erro de validação no caso de email duplicado
