### PR TITLE
DMF01-40-Cadastro-de-país-e-estados-do-país

### DIFF
--- a/src/main/java/com/dmf/loja/categoria/Categoria.java
+++ b/src/main/java/com/dmf/loja/categoria/Categoria.java
@@ -18,10 +18,6 @@ public class Categoria {
     @Column(nullable = false, unique = true)
     private String nome;
 
-    // Lado inverso: mapeia os livros com o atributo "autor" da entidade Livro.
-//    @OneToMany(mappedBy = "autor", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private Set<Livro> livros = new HashSet<>();
-
     public Categoria(String nome) {
         Assert.hasText(nome, "O nome é obrigatório");
         this.nome = nome;

--- a/src/main/java/com/dmf/loja/paisestado/Estado.java
+++ b/src/main/java/com/dmf/loja/paisestado/Estado.java
@@ -1,0 +1,37 @@
+package com.dmf.loja.paisestado;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Entity
+public class Estado {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @NotBlank private String nome;
+
+    @ManyToOne
+    @JoinColumn(name = "pais_id", nullable = false)
+    @NotNull private Pais pais;
+
+    public Estado(String nome, Pais pais) {
+        this.nome = nome;
+        this.pais = pais;
+    }
+
+    @Deprecated
+    public Estado() {
+    }
+
+    @Override
+    public String toString() {
+        return "Estado{" +
+                "id=" + id +
+                ", nome='" + nome + '\'' +
+                ", pais=" + pais +
+                '}';
+    }
+}

--- a/src/main/java/com/dmf/loja/paisestado/Estado.java
+++ b/src/main/java/com/dmf/loja/paisestado/Estado.java
@@ -3,6 +3,7 @@ package com.dmf.loja.paisestado;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.util.Assert;
 
 @Entity
 public class Estado {
@@ -18,6 +19,9 @@ public class Estado {
     @NotNull private Pais pais;
 
     public Estado(String nome, Pais pais) {
+        Assert.hasText(nome, "O nome é obrigatório");
+        Assert.notNull(pais, "O País não pode ser nulo");
+
         this.nome = nome;
         this.pais = pais;
     }

--- a/src/main/java/com/dmf/loja/paisestado/EstadosController.java
+++ b/src/main/java/com/dmf/loja/paisestado/EstadosController.java
@@ -8,20 +8,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class PaisEstadoController {
+public class EstadosController {
 
     private final EntityManager entityManager;
 
-    public PaisEstadoController(EntityManager entityManager) {
+    public EstadosController(EntityManager entityManager) {
         this.entityManager = entityManager;
     }
 
-    @PostMapping("/paises")
+    @PostMapping("/estados")
     @Transactional
-    public String cadastraPais(@RequestBody @Valid NovoPaisRequest novoPaisRequest) {
-        Pais novoPais = novoPaisRequest.toModel();
-        entityManager.persist(novoPais);
-        return novoPais.toString();
+    public String cadastraEstado(@RequestBody @Valid NovoEstadoRequest novoEstadoRequest) {
+        Estado novoEstado = novoEstadoRequest.toModel(entityManager);
+        entityManager.persist(novoEstado);
+        return novoEstado.toString();
     }
 
 }

--- a/src/main/java/com/dmf/loja/paisestado/NovoEstadoRequest.java
+++ b/src/main/java/com/dmf/loja/paisestado/NovoEstadoRequest.java
@@ -1,0 +1,26 @@
+package com.dmf.loja.paisestado;
+
+import com.dmf.loja.validation.campounicoannotation.CampoUnico;
+import com.dmf.loja.validation.existeid.ExisteId;
+import jakarta.persistence.EntityManager;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.util.Assert;
+
+public record NovoEstadoRequest(
+        @CampoUnico(fieldName = "nome", domainClass = Estado.class)
+        @NotBlank String nome,
+
+        @ExisteId(fieldName = "id", domainClass = Pais.class)
+        @NotNull Long idPais
+) {
+    Estado toModel(EntityManager entityManager) {
+        Pais pais = entityManager.find(Pais.class, idPais);
+        Assert.state(pais != null, "Você está querendo cadastrar um Estado com um País que não existe no banco");
+
+        return new Estado(
+                this.nome(),
+                pais
+        );
+    }
+}

--- a/src/main/java/com/dmf/loja/paisestado/NovoPaisRequest.java
+++ b/src/main/java/com/dmf/loja/paisestado/NovoPaisRequest.java
@@ -1,0 +1,13 @@
+package com.dmf.loja.paisestado;
+
+import com.dmf.loja.validation.campounicoannotation.CampoUnico;
+import jakarta.validation.constraints.NotBlank;
+
+public record NovoPaisRequest(
+        @CampoUnico(domainClass = Pais.class, fieldName = "nome")
+        @NotBlank String nome
+) {
+    public Pais toModel() {
+        return new Pais(this.nome);
+    }
+}

--- a/src/main/java/com/dmf/loja/paisestado/Pais.java
+++ b/src/main/java/com/dmf/loja/paisestado/Pais.java
@@ -19,12 +19,8 @@ public class Pais {
         this.nome = nome;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public String getNome() {
-        return nome;
+    @Deprecated
+    public Pais() {
     }
 
     @Override

--- a/src/main/java/com/dmf/loja/paisestado/Pais.java
+++ b/src/main/java/com/dmf/loja/paisestado/Pais.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.util.Assert;
 
 @Entity
 public class Pais {
@@ -16,6 +17,8 @@ public class Pais {
     private String nome;
 
     public Pais(String nome) {
+        Assert.hasText(nome, "O nome é obrigatório");
+
         this.nome = nome;
     }
 

--- a/src/main/java/com/dmf/loja/paisestado/Pais.java
+++ b/src/main/java/com/dmf/loja/paisestado/Pais.java
@@ -1,0 +1,37 @@
+package com.dmf.loja.paisestado;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+
+@Entity
+public class Pais {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @NotBlank
+    private String nome;
+
+    public Pais(String nome) {
+        this.nome = nome;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    @Override
+    public String toString() {
+        return "Pais{" +
+                "id='" + id + '\'' +
+                ", nome='" + nome + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/dmf/loja/paisestado/PaisEstadoController.java
+++ b/src/main/java/com/dmf/loja/paisestado/PaisEstadoController.java
@@ -1,0 +1,27 @@
+package com.dmf.loja.paisestado;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PaisEstadoController {
+
+    private final EntityManager entityManager;
+
+    public PaisEstadoController(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @PostMapping("/paises")
+    @Transactional
+    public String cadastraPais(@RequestBody @Valid NovoPaisRequest novoPaisRequest) {
+        Pais novoPais = novoPaisRequest.toModel();
+        entityManager.persist(novoPais);
+        return novoPais.toString();
+    }
+
+}

--- a/src/main/java/com/dmf/loja/paisestado/PaisesController.java
+++ b/src/main/java/com/dmf/loja/paisestado/PaisesController.java
@@ -1,0 +1,27 @@
+package com.dmf.loja.paisestado;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PaisesController {
+
+    private final EntityManager entityManager;
+
+    public PaisesController(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @PostMapping("/paises")
+    @Transactional
+    public String cadastraPais(@RequestBody @Valid NovoPaisRequest novoPaisRequest) {
+        Pais novoPais = novoPaisRequest.toModel();
+        entityManager.persist(novoPais);
+        return novoPais.toString();
+    }
+
+}


### PR DESCRIPTION
necessidades

Precisamos de um cadastro simples de países e seus respectivos estados.

Cada país tem um nome e cada estado tem um nome e pertence a um país.

restrições para país

o nome é obrigatório

o nome é único

restrição para estados

o nome é obrigatório

o nome é único

o país é obrigatório

resultado esperado

Dois endpoints para que seja possível cadastrar países e estados. Pode existir país sem estados associados.

Caso alguma restrição não seja atendida, retornar 400 e json com os problemas de validação.